### PR TITLE
opam-publish.0.3.0 - via opam-publish

### DIFF
--- a/packages/opam-publish/opam-publish.0.3.0/descr
+++ b/packages/opam-publish/opam-publish.0.3.0/descr
@@ -1,0 +1,4 @@
+A tool to ease contributions to opam repositories.
+
+Opam-publish helps gather metadata to form an OPAM package and submit it
+to a remote repository.

--- a/packages/opam-publish/opam-publish.0.3.0/opam
+++ b/packages/opam-publish/opam-publish.0.3.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+homepage: "http://opam.ocaml.org"
+bug-reports: "https://github.com/AltGr/opam-publish/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/AltGr/opam-publish.git"
+build: [make]
+depends: [
+  "opam-lib" {build & >= "1.2.0"}
+  "ocamlfind" {build}
+  "cmdliner" {build}
+  "github" {build & >= "1.0.0"}
+]

--- a/packages/opam-publish/opam-publish.0.3.0/url
+++ b/packages/opam-publish/opam-publish.0.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dsheets/opam-publish/archive/0.3.0.tar.gz"
+checksum: "fdfff5c710699e3d62409b20a44df55d"


### PR DESCRIPTION
A tool to ease contributions to opam repositories.

Opam-publish helps gather metadata to form an OPAM package and submit it
to a remote repository.

---
- Homepage: http://opam.ocaml.org
- Source repo: https://github.com/AltGr/opam-publish.git
- Bug tracker: https://github.com/AltGr/opam-publish/issues

---

Pull-request generated by opam-publish v0.3.0
